### PR TITLE
템플릿 메서드 패턴

### DIFF
--- a/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderControllerV4.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderControllerV4.kt
@@ -1,0 +1,28 @@
+package com.example.advanced.app.v4
+
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+class OrderControllerV4(
+    private val orderServiceV4: OrderServiceV4,
+    private val trace: LogTrace
+) {
+    @GetMapping("/v4/request")
+    fun request(@RequestParam itemId: String): String {
+
+
+        val template = object : AbstractTemplate<String>(trace) {
+            override fun call(): String {
+                orderServiceV4.order(itemId)
+                return "ok"
+            }
+        }
+
+        return template.execute("OrderController.request")
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderRepositoryV4.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderRepositoryV4.kt
@@ -1,0 +1,33 @@
+package com.example.advanced.app.v4
+
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrderRepositoryV4(
+    private val trace: LogTrace
+) {
+
+    fun save(itemId: String) {
+        // 저장 로직
+
+        val template = object : AbstractTemplate<Unit>(trace) {
+            override fun call() {
+                require(itemId != "ex") { "잘못된 상품 ID: $itemId" }
+                sleep(1000)
+            }
+        }
+
+        template.execute("OrderRepository.save")
+
+    }
+
+    private fun sleep(millis: Long) {
+        try {
+            Thread.sleep(millis)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderServiceV4.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v4/OrderServiceV4.kt
@@ -1,0 +1,25 @@
+package com.example.advanced.app.v4
+
+
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.stereotype.Service
+
+
+@Service
+class OrderServiceV4(
+    private val orderRepositoryV4: OrderRepositoryV4,
+    private val trace: LogTrace
+) {
+
+    fun order(itemId: String) {
+
+        val template = object : AbstractTemplate<Unit>(trace) {
+            override fun call() {
+                orderRepositoryV4.save(itemId)
+            }
+        }
+
+        template.execute("OrderService.order")
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/trace/template/AbstractTemplate.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/trace/template/AbstractTemplate.kt
@@ -1,0 +1,26 @@
+package com.example.advanced.trace.template
+
+import com.example.advanced.trace.logtrace.LogTrace
+
+abstract class AbstractTemplate<T>(
+    private val trace: LogTrace,
+) {
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    abstract fun call(): T
+
+    fun execute(message: String): T {
+        val status = trace.begin(message)
+
+        try {
+            val result: T = call()
+            trace.end(status)
+            return result
+        } catch (e: Exception) {
+            trace.exception(status, e)
+            throw e
+        }
+    }
+
+
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/TemplateMethodTest.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/TemplateMethodTest.kt
@@ -1,0 +1,49 @@
+package com.example.advanced.trace.template
+
+import com.example.advanced.trace.template.code.SubClassLogic1
+import com.example.advanced.trace.template.code.SubClassLogic2
+import org.junit.jupiter.api.Test
+
+class TemplateMethodTest {
+
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    @Test
+    fun templateMethodV0() {
+        logic1()
+        logic2()
+    }
+
+
+    private fun logic1() {
+        val startTime = System.currentTimeMillis()
+        log.info("logic1() 시작")
+        val endTime = System.currentTimeMillis()
+        val resultTime = endTime - startTime
+        log.info(resultTime.toString())
+        log.info("logic1() 종료")
+    }
+
+    private fun logic2() {
+        val startTime = System.currentTimeMillis()
+        log.info("logic2() 시작")
+        val endTime = System.currentTimeMillis()
+        val resultTime = endTime - startTime
+        log.info(resultTime.toString())
+        log.info("logic2() 종료")
+    }
+
+
+    /**
+     * Template Method Pattern
+     * 단일 책임 원칙을 지키며 중복된 코드를 제거하는 방법
+     */
+    @Test
+    fun templateMethodV1() {
+        val logic1 = SubClassLogic1()
+        logic1.execute()
+
+        val logic2 = SubClassLogic2()
+        logic2.execute()
+    }
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/TemplateMethodTest.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/TemplateMethodTest.kt
@@ -46,4 +46,26 @@ class TemplateMethodTest {
         val logic2 = SubClassLogic2()
         logic2.execute()
     }
+
+
+    /**
+     * 익명 내부 클래스로 구현하기
+     */
+
+    @Test
+    fun templateMethodV2() {
+        val logic1 = object : SubClassLogic1() {
+            override fun call() {
+                log.info("비즈니스 로직 1")
+            }
+        }
+        logic1.execute()
+
+        val logic2 = object : SubClassLogic2() {
+            override fun call() {
+                log.info("비즈니스 로직 2")
+            }
+        }
+        logic2.execute()
+    }
 }

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/code/AbstractTemplate.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/code/AbstractTemplate.kt
@@ -1,0 +1,15 @@
+package com.example.advanced.trace.template.code
+
+abstract class AbstractTemplate {
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    fun execute() {
+        val startTime = System.currentTimeMillis()
+        call()
+        val endTime = System.currentTimeMillis()
+        val resultTime = endTime - startTime
+        log.info(resultTime.toString())
+    }
+
+    protected abstract fun call();
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic1.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic1.kt
@@ -1,0 +1,11 @@
+package com.example.advanced.trace.template.code
+
+class SubClassLogic1 : AbstractTemplate() {
+
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    override fun call() {
+        log.info("비즈니스 로직 1")
+    }
+
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic1.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic1.kt
@@ -1,6 +1,6 @@
 package com.example.advanced.trace.template.code
 
-class SubClassLogic1 : AbstractTemplate() {
+open class SubClassLogic1 : AbstractTemplate() {
 
     private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
 

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic2.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic2.kt
@@ -1,0 +1,10 @@
+package com.example.advanced.trace.template.code
+
+class SubClassLogic2 : AbstractTemplate() {
+
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    override fun call() {
+        log.info("비즈니스 로직 2")
+    }
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic2.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/template/code/SubClassLogic2.kt
@@ -1,6 +1,6 @@
 package com.example.advanced.trace.template.code
 
-class SubClassLogic2 : AbstractTemplate() {
+open class SubClassLogic2 : AbstractTemplate() {
 
     private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION

템플릿 메서드 디자인 패턴의 목적은 다음과 같습니다.
"작업에서 알고리즘의 골격을 정의하고 일부 단계를 하위 클래스로 연기합니다. 템플릿 메서드를 사용하면 하위 클래스가 알고리즘의 구조를 변경하지 않고도 알고리즘의 특정 단계를 재정의할 수 있습니다." [GOF]

### 템플릿 메서드 패턴의 정의 
- 모 클래스에 알고리즘의 골격인 템플릿을 정의하고, 일부 변경되는 로직은 자식 클래스에 정의하는 것이다. 이렇게 하 면 자식 클래스가 알고리즘의 전체 구조를 변경하지 않고, 특정 부분만 재정의할 수 있다. 결국 상속과 오버라이딩을 통 한 다형성으로 문제를 해결하는 것이다.
**하지만**
- 템플릿 메서드 패턴은 상속을 사용한다. 따라서 상속에서 오는 단점들을 그대로 안고간다. 특히 자식 클래스가 부모 클 래스와 컴파일 시점에 강하게 결합되는 문제가 있다. 이것은 의존관계에 대한 문제이다. 자식 클래스 입장에서는 부모 클래스의 기능을 전혀 사용하지 않는다.

### 지금까지 작성했던 코드를 떠올려보자. 자식 클래스를 작성할 때 부모 클래스의 기능을 사용한 것이 있었던가?
그럼에도 불구하고 템플릿 메서드 패턴을 위해 자식 클래스는 부모 클래스를 상속 받고 있다.
상속을 받는 다는 것은 특정 부모 클래스를 의존하고 있다는 것이다. 자식 클래스의 `extends` 다음에 바로 부모 클래 스가 코드상에 지정되어 있다. 따라서 부모 클래스의 기능을 사용하든 사용하지 않든 간에 부모 클래스를 강하게 의존하 게 된다. 여기서 강하게 의존한다는 뜻은 자식 클래스의 코드에 부모 클래스의 코드가 명확하게 적혀 있다는 뜻이다. UML에서 상속을 받으면 삼각형 화살표가 `자식 -> 부모` 를 향하고 있는 것은 이런 의존관계를 반영하는 것이다.
자식 클래스 입장에서는 부모 클래스의 기능을 전혀 사용하지 않는데, 부모 클래스를 알아야한다. 이것은 좋은 설계가 아니다. 그리고 이런 잘못된 의존관계 때문에 부모 클래스를 수정하면, 자식 클래스에도 영향을 줄 수 있다.

