### PR TITLE
템플릿 콜백 패턴

### DIFF
--- a/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderControllerV5.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderControllerV5.kt
@@ -1,0 +1,29 @@
+package com.example.advanced.app.v5
+
+import com.example.advanced.trace.callback.TraceCallback
+import com.example.advanced.trace.callback.TraceTemplate
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+class OrderControllerV5(
+    private val orderServiceV5: OrderServiceV5,
+    private val trace: LogTrace,
+    private val traceTemplate: TraceTemplate = TraceTemplate(trace = trace),
+) {
+    @GetMapping("/v5/request")
+    fun request(@RequestParam itemId: String): String {
+
+        return traceTemplate.execute("OrderController.request",
+            object : TraceCallback<String> {
+                override fun call(): String {
+                    orderServiceV5.order(itemId)
+                    return "ok"
+                }
+            })
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderRepositoryV5.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderRepositoryV5.kt
@@ -1,0 +1,31 @@
+package com.example.advanced.app.v5
+
+import com.example.advanced.trace.callback.TraceCallback
+import com.example.advanced.trace.callback.TraceTemplate
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class OrderRepositoryV5(
+    private val trace: LogTrace,
+    private val template: TraceTemplate = TraceTemplate(trace)
+) {
+
+    fun save(itemId: String) {
+        template.execute("OrderRepository.save", object : TraceCallback<Unit> {
+            override fun call() {
+                require(itemId != "ex") { "잘못된 상품 ID: $itemId" }
+                sleep(1000)
+            }
+        })
+    }
+
+    private fun sleep(millis: Long) {
+        try {
+            Thread.sleep(millis)
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderServiceV5.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/app/v5/OrderServiceV5.kt
@@ -1,0 +1,27 @@
+package com.example.advanced.app.v5
+
+
+import com.example.advanced.trace.callback.TraceCallback
+import com.example.advanced.trace.callback.TraceTemplate
+import com.example.advanced.trace.logtrace.LogTrace
+import com.example.advanced.trace.template.AbstractTemplate
+import org.springframework.stereotype.Service
+
+
+@Service
+class OrderServiceV5(
+    private val orderRepositoryV5: OrderRepositoryV5,
+    private val trace: LogTrace,
+    private val template : TraceTemplate = TraceTemplate(trace)
+) {
+
+    fun order(itemId: String) {
+        template.execute("OrderService.order",
+            object : TraceCallback<Unit> {
+                override fun call() {
+                    orderRepositoryV5.save(itemId)
+                }
+            }
+        )
+    }
+}

--- a/advanced/src/main/kotlin/com/example/advanced/trace/callback/TraceCallback.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/trace/callback/TraceCallback.kt
@@ -1,0 +1,5 @@
+package com.example.advanced.trace.callback
+
+interface TraceCallback<T> {
+    fun call(): T
+}

--- a/advanced/src/main/kotlin/com/example/advanced/trace/callback/TraceTemplate.kt
+++ b/advanced/src/main/kotlin/com/example/advanced/trace/callback/TraceTemplate.kt
@@ -1,0 +1,23 @@
+package com.example.advanced.trace.callback
+
+import com.example.advanced.trace.logtrace.LogTrace
+import org.springframework.stereotype.Component
+
+@Component
+class TraceTemplate (
+    private val trace: LogTrace
+){
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    fun <T> execute(message: String, callback: TraceCallback<T>): T {
+        val status = trace.begin(message)
+        try {
+            val result = callback.call()
+            trace.end(status)
+            return result
+        } catch (e: Exception) {
+            trace.exception(status, e)
+            throw e
+        }
+    }
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/strategy/TemplateCallbackTest.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/strategy/TemplateCallbackTest.kt
@@ -1,0 +1,16 @@
+package com.example.advanced.trace.strategy
+
+import com.example.advanced.trace.strategy.code.template.Callback
+import com.example.advanced.trace.strategy.code.template.TimeLogTemplate
+import org.junit.jupiter.api.Test
+
+class TemplateCallbackTest {
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    @Test
+    fun callbackV1() {
+        val template = TimeLogTemplate()
+        template.execute { log.info("비즈니스 로직 1 실행") }
+        template.execute { log.info("비즈니스 로직 2 실행") }
+    }
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/strategy/code/template/Callback.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/strategy/code/template/Callback.kt
@@ -1,0 +1,5 @@
+package com.example.advanced.trace.strategy.code.template
+
+fun interface Callback {
+    fun call()
+}

--- a/advanced/src/test/kotlin/com/example/advanced/trace/strategy/code/template/TimeLogTemplate.kt
+++ b/advanced/src/test/kotlin/com/example/advanced/trace/strategy/code/template/TimeLogTemplate.kt
@@ -1,0 +1,14 @@
+package com.example.advanced.trace.strategy.code.template
+
+class TimeLogTemplate {
+
+    private val log = org.slf4j.LoggerFactory.getLogger(this::class.java)
+
+    fun execute(callback: Callback) {
+        val startTime = System.currentTimeMillis()
+        callback.call()
+        val endTime = System.currentTimeMillis()
+        val resultTime = endTime - startTime
+        log.info(resultTime.toString())
+    }
+}


### PR DESCRIPTION
### 콜백
프로그래밍에서 콜백(callback) 또는 콜애프터 함수(call-after function)는 다른 코드의 인수로서 넘겨주는 실 행 가능한 코드를 말한다. 콜백을 넘겨받는 코드는 이 콜백을 필요에 따라 즉시 실행할 수도 있고, 아니면 나중에 실행할 수도 있다. (위키백과 참고)

### 템플릿 콜백 패턴
스프링에서는 `ContextV2` 와 같은 방식의 전략 패턴을 템플릿 콜백 패턴이라 한다. 전략 패턴에서 `Context` 가 템플릿 역할을 하고, `Strategy` 부분이 콜백으로 넘어온다 생각하면 된다.
참고로 템플릿 콜백 패턴은 GOF 패턴은 아니고, 스프링 내부에서 이런 방식을 자주 사용하기 때문에, 스프링 안 에서만 이렇게 부른다. 전략 패턴에서 템플릿과 콜백 부분이 강조된 패턴이라 생각하면 된다.
스프링에서는 `JdbcTemplate` , `RestTemplate` , `TransactionTemplate` , `RedisTemplate` 처럼 다양 한 템플릿 콜백 패턴이 사용된다. 스프링에서 이름에 `XxxTemplate` 가 있다면 템플릿 콜백 패턴으로 만들어져 있다 생각하면 된다.


**한계**
그런데 지금까지 설명한 방식의 한계는 아무리 최적화를 해도 결국 로그 추적기를 적용하기 위해서 원본 코드를 수정해야 한다는 점이다. 클래스가 수백개이면 수백개를 더 힘들게 수정하는가 조금 덜 힘들게 수정하는가의 차이가 있을 뿐, 본질적으로 코드를 다 수정해야 하는 것은 마찬가지이다.
개발자의 게으름에 대한 욕심은 끝이 없다. 수 많은 개발자가 이 문제에 대해서 집요하게 고민해왔고, 여러가지 방향으 로 해결책을 만들어왔다. 지금부터 원본 코드를 손대지 않고 로그 추적기를 적용할 수 있는 방법을 알아보자. 그러기 위해서 프록시 개념을 먼저 이해해야 한다.